### PR TITLE
Fix: GestureHandler for Android.

### DIFF
--- a/src/components/draw-control/gesture-responder.tsx
+++ b/src/components/draw-control/gesture-responder.tsx
@@ -43,6 +43,7 @@ const GestureHandler: FC<TGestureControl> = ({
         right: 0,
         top: 0,
         bottom: 0,
+        zIndex: 1,
       }}
       {...panResponder.panHandlers}
     />


### PR DESCRIPTION
Gestures not registering on Android - unable to draw on map, issue ticket here:  https://github.com/dev-event/react-native-maps-draw/issues/13