### PR TITLE
upgrade react-native-svg to 13.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,6 @@
   "dependencies": {
     "geolib": "3.3.3",
     "invariant": "^2.2.4",
-    "react-native-svg": "13.6.0"
+    "react-native-svg": "13.9.0"
   }
 }


### PR DESCRIPTION
Due to the update to Expo Modules, this package no longer works with Expo projects which require react-native-svg@13.9.0