### PR TITLE
Use scoped package name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-maps-draw",
+  "name": "@dev-event/react-native-maps-draw",
   "version": "0.1.0",
   "description": "test",
   "main": "lib/commonjs/index",


### PR DESCRIPTION
# Why

It causes a data mismatch when fetching information for React Native Directory:

![Screenshot 2024-10-11 at 13 33 47](https://github.com/user-attachments/assets/0dda1e86-5d40-47c6-88d7-60e7567ce50b)

# How

Use scoped package name in `package.json` file.

https://www.npmjs.com/package/@dev-event/react-native-maps-draw